### PR TITLE
Adding workaround for old path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN wget "$SIA_RELEASE" && \
 # Workaround for backwards compatibility with old images, which hardcoded the
 # Sia data directory as /mnt/sia. Creates a symbolic link so that any previous
 # path references stored in the Sia host config still work.
-RUN ln -s "$SIA_DATA_DIR" /mnt/sia
+RUN ln --symbolic "$SIA_DATA_DIR" /mnt/sia
 
 # Clean up.
 RUN apt-get remove -y wget unzip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,11 @@ RUN wget "$SIA_RELEASE" && \
       unzip -j "$SIA_ZIP" "${SIA_PACKAGE}/siac" -d "$SIA_DIR" && \
       unzip -j "$SIA_ZIP" "${SIA_PACKAGE}/siad" -d "$SIA_DIR"
 
+# Workaround for backwards compatibility with old images, which hardcoded the
+# Sia data directory as /mnt/sia. Creates a symbolic link so that any previous
+# path references stored in the Sia host config still work.
+RUN ln -s "$SIA_DATA_DIR" /mnt/sia
+
 # Clean up.
 RUN apt-get remove -y wget unzip && \
     rm "$SIA_ZIP" && \


### PR DESCRIPTION
The previous Sia image used a Sia dir path of /mnt/sia. If users upgraded from the old image to the new with hosting enabled, Sia would have stored the old paths. This adds a symlink so that the old path still works.